### PR TITLE
issue to consume this code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GIT_USER_ID/GIT_REPO_ID
+module  github.com/mailslurp/mailslurp-client-go
 
 require (
 	github.com/antihax/optional v1.0.0


### PR DESCRIPTION
Problem :
```shell
go get github.com/mailslurp/mailslurp-client-go
```

 fail:

```
go get: github.com/mailslurp/mailslurp-client-go@v0.0.0-20200216140629-2917958df7dd: parsing go.mod:
        module declares its path as: github.com/GIT_USER_ID/GIT_REPO_ID
                but was required as: github.com/mailslurp/mailslurp-client-go
```